### PR TITLE
Delete Reddit - Quality Guidelines #173

### DIFF
--- a/declarations/Reddit.json
+++ b/declarations/Reddit.json
@@ -11,16 +11,6 @@
       "remove": ".filter-holder",
       "select": "#main-content"
     },
-    "Live Policy": {
-      "fetch": "https://www.redditinc.com/policies/broadcasting-content-policy",
-      "remove": ".filter-holder",
-      "select": "#content"
-    },
-    "Quality Guidelines": {
-      "fetch": "https://www.redditinc.com/policies/content-policy",
-      "remove": ".filter-holder",
-      "select": "#content"
-    },
     "Community Guidelines": {
       "select": [
         "#main-content"


### PR DESCRIPTION
Deleted the duplicate (Quality Guidelines = Content Policy in Community Guidelines) and non-existent terms (Live Policy - deleted from the website)